### PR TITLE
Fix base path for static files findout

### DIFF
--- a/denyhosts_server/config.py
+++ b/denyhosts_server/config.py
@@ -17,6 +17,7 @@
 import ConfigParser
 import inspect
 import logging
+import os
 import os.path
 import sys
 import sqlite3
@@ -122,7 +123,11 @@ def read_config(filename):
             loglevel = logging.INFO
 
     stats_frequency = _getint(_config, "stats", "update_frequency", 600)
-    package_dir =  os.path.dirname(os.path.dirname(inspect.getsourcefile(read_config)))
+    # By default - static files placed in process working directory
+    package_dir = os.getcwd()
+    if not os.path.exists( os.path.join( package_dir, "static" ) ):
+        # If not - use developer or inplace working path
+        package_dir =  os.path.dirname(os.path.dirname(inspect.getsourcefile(read_config)))
     static_dir = _get(_config, "stats", "static_dir", 
         os.path.join( 
             package_dir,


### PR DESCRIPTION
The problem conditions are:
1. Created deb package with:
- project files in /usr/share/pyshared/denyhosts_server
- project static, templates and db files - in /var/lib/denyhosts-server
  1. service is started by start-stop-daemon and workdir in /var/lib/denyhosts-server

So, do check for static base path at first in process workdir, second - in project dir.
