### PR TITLE
Add support for set service listen on defined address

### DIFF
--- a/denyhosts-server.conf.example
+++ b/denyhosts-server.conf.example
@@ -43,6 +43,9 @@
 # denyhosts clients per sync. Default: 50
 #max_reported_crackers: 50
 
+# TCP addr to listen on. Default: empty (all)
+#listen_host:
+
 # TCP port to listen on. Default: 9911
 #listen_port: 9911
 
@@ -109,6 +112,10 @@
 # Whether to resolve hostnames for the IP addresses in the statistics
 # Default: yes
 #resolve_hostnames: yes
+
+# TCP addr to serve statistics. Can be the same a the listen_host in the
+# [sync] section. Default: empty (all)
+#listen_host:
 
 # TCP port to serve statistics. Can be the same a the listen_port in the
 # [sync] section. Default: 9911

--- a/denyhosts-server.conf.example
+++ b/denyhosts-server.conf.example
@@ -44,7 +44,7 @@
 #max_reported_crackers: 50
 
 # TCP addr to listen on. Default: empty (all)
-#listen_host:
+#listen_address:
 
 # TCP port to listen on. Default: 9911
 #listen_port: 9911
@@ -113,9 +113,9 @@
 # Default: yes
 #resolve_hostnames: yes
 
-# TCP addr to serve statistics. Can be the same a the listen_host in the
+# TCP addr to serve statistics. Can be the same a the listen_address in the
 # [sync] section. Default: empty (all)
-#listen_host:
+#listen_address:
 
 # TCP port to serve statistics. Can be the same a the listen_port in the
 # [sync] section. Default: 9911

--- a/denyhosts_server/config.py
+++ b/denyhosts_server/config.py
@@ -55,6 +55,7 @@ def read_config(filename):
     global max_reported_crackers
     global logfile
     global loglevel
+    global xmlrpc_listen_host
     global xmlrpc_listen_port
     global legacy_server
     global legacy_frequency
@@ -62,6 +63,7 @@ def read_config(filename):
     global enable_debug_methods
     global stats_frequency
     global stats_resolve_hostnames
+    global stats_listen_host
     global stats_listen_port
     global static_dir, graph_dir, template_dir
 
@@ -103,6 +105,7 @@ def read_config(filename):
     legacy_expiry_days = _getfloat(_config, "maintenance", "legacy_expiry_days", 30)
 
     max_reported_crackers = _getint(_config, "sync", "max_reported_crackers", 50)
+    xmlrpc_listen_host = _get(_config, "sync", "listen_host", "")
     xmlrpc_listen_port = _getint(_config, "sync", "listen_port", 9911)
     enable_debug_methods = _getboolean(_config, "sync", "enable_debug_methods", False)
     legacy_server = _get(_config, "sync", "legacy_server", None)
@@ -130,4 +133,5 @@ def read_config(filename):
     graph_dir = _get(_config, "stats", "graph_dir", os.path.join(static_dir, "graph"))
     template_dir = _get(_config, "stats", "template_dir", os.path.join(package_dir, "template"))
     stats_resolve_hostnames = _getboolean(_config, "stats", "resolve_hostnames", True)
+    stats_listen_host = _get(_config, "stats", "listen_host", "")
     stats_listen_port = _getint(_config, "stats", "listen_port", 9911)

--- a/denyhosts_server/config.py
+++ b/denyhosts_server/config.py
@@ -55,7 +55,7 @@ def read_config(filename):
     global max_reported_crackers
     global logfile
     global loglevel
-    global xmlrpc_listen_host
+    global xmlrpc_listen_address
     global xmlrpc_listen_port
     global legacy_server
     global legacy_frequency
@@ -63,7 +63,7 @@ def read_config(filename):
     global enable_debug_methods
     global stats_frequency
     global stats_resolve_hostnames
-    global stats_listen_host
+    global stats_listen_address
     global stats_listen_port
     global static_dir, graph_dir, template_dir
 
@@ -105,7 +105,7 @@ def read_config(filename):
     legacy_expiry_days = _getfloat(_config, "maintenance", "legacy_expiry_days", 30)
 
     max_reported_crackers = _getint(_config, "sync", "max_reported_crackers", 50)
-    xmlrpc_listen_host = _get(_config, "sync", "listen_host", "")
+    xmlrpc_listen_address = _get(_config, "sync", "listen_address", "")
     xmlrpc_listen_port = _getint(_config, "sync", "listen_port", 9911)
     enable_debug_methods = _getboolean(_config, "sync", "enable_debug_methods", False)
     legacy_server = _get(_config, "sync", "legacy_server", None)
@@ -133,5 +133,5 @@ def read_config(filename):
     graph_dir = _get(_config, "stats", "graph_dir", os.path.join(static_dir, "graph"))
     template_dir = _get(_config, "stats", "template_dir", os.path.join(package_dir, "template"))
     stats_resolve_hostnames = _getboolean(_config, "stats", "resolve_hostnames", True)
-    stats_listen_host = _get(_config, "stats", "listen_host", "")
+    stats_listen_address = _get(_config, "stats", "listen_address", "")
     stats_listen_port = _getint(_config, "stats", "listen_port", 9911)

--- a/denyhosts_server/main.py
+++ b/denyhosts_server/main.py
@@ -165,15 +165,15 @@ def start_listening():
     # /static/graphs
     web_static.putChild('graphs', web_graphs)
 
-    logging.info("Start listening on port {}".format(config.xmlrpc_listen_port))
+    logging.info("Start listening on host:port {}:{}".format(config.xmlrpc_listen_host, config.xmlrpc_listen_port))
     _xmlrpc_site = server.Site(xmlrpc_root)
-    _xmlrpc_listener = reactor.listenTCP(config.xmlrpc_listen_port, _xmlrpc_site)
+    _xmlrpc_listener = reactor.listenTCP(config.xmlrpc_listen_port, _xmlrpc_site, interface=config.xmlrpc_listen_host)
 
-    if config.stats_listen_port == config.xmlrpc_listen_port:
+    if config.stats_listen_port == config.xmlrpc_listen_port and config.xmlrpc_listen_host == config.stats_listen_host:
         _stats_listener = None
     else:
-        logging.info("Start serving statistics on port {}".format(config.stats_listen_port))
-        _stats_listener = reactor.listenTCP(config.stats_listen_port, server.Site(stats_root))
+        logging.info("Start serving statistics on host:port {}:{}".format(config.stats_listen_host, config.stats_listen_port))
+        _stats_listener = reactor.listenTCP(config.stats_listen_port, server.Site(stats_root), interface=config.stats_listen_host)
 
 maintenance_job = None
 legacy_sync_job = None

--- a/denyhosts_server/main.py
+++ b/denyhosts_server/main.py
@@ -165,15 +165,15 @@ def start_listening():
     # /static/graphs
     web_static.putChild('graphs', web_graphs)
 
-    logging.info("Start listening on host:port {}:{}".format(config.xmlrpc_listen_host, config.xmlrpc_listen_port))
+    logging.info("Start listening on host:port {}:{}".format(config.xmlrpc_listen_address, config.xmlrpc_listen_port))
     _xmlrpc_site = server.Site(xmlrpc_root)
-    _xmlrpc_listener = reactor.listenTCP(config.xmlrpc_listen_port, _xmlrpc_site, interface=config.xmlrpc_listen_host)
+    _xmlrpc_listener = reactor.listenTCP(config.xmlrpc_listen_port, _xmlrpc_site, interface=config.xmlrpc_listen_address)
 
-    if config.stats_listen_port == config.xmlrpc_listen_port and config.xmlrpc_listen_host == config.stats_listen_host:
+    if config.stats_listen_port == config.xmlrpc_listen_port and config.xmlrpc_listen_address == config.stats_listen_address:
         _stats_listener = None
     else:
-        logging.info("Start serving statistics on host:port {}:{}".format(config.stats_listen_host, config.stats_listen_port))
-        _stats_listener = reactor.listenTCP(config.stats_listen_port, server.Site(stats_root), interface=config.stats_listen_host)
+        logging.info("Start serving statistics on host:port {}:{}".format(config.stats_listen_address, config.stats_listen_port))
+        _stats_listener = reactor.listenTCP(config.stats_listen_port, server.Site(stats_root), interface=config.stats_listen_address)
 
 maintenance_job = None
 legacy_sync_job = None


### PR DESCRIPTION
- new option - listen_host

It is needed if we want hide service behind nginx/proxy.
And set it listen on localhost.
